### PR TITLE
Typos in ExportFFmpeg.cpp

### DIFF
--- a/src/export/ExportFFmpeg.cpp
+++ b/src/export/ExportFFmpeg.cpp
@@ -193,7 +193,7 @@ ExportFFmpeg::ExportFFmpeg()
    for (newfmt = 0; newfmt < FMT_LAST; newfmt++)
    {
       wxString shortname(ExportFFmpegOptions::fmts[newfmt].shortname);
-      //Don't hide export types when there's no av-libs, and don't hide FMT_OTHER
+      // Don't hide export types when there's no av-libs, and don't hide FMT_OTHER
       if (newfmt < FMT_OTHER && FFmpegLibsInst()->ValidLibsLoaded())
       {
          // Format/Codec support is compiled in?
@@ -766,7 +766,7 @@ static int encode_audio(AVCodecContext *avctx, AVPacket *pkt, int16_t *audio_sam
       return ret;
    }
 
-   pkt->dts = pkt->pts = AV_NOPTS_VALUE; // we dont set frame.pts thus dont trust the AVPacket ts
+   pkt->dts = pkt->pts = AV_NOPTS_VALUE; // We don't set frame.pts thus don't trust the AVPacket ts
 
    return got_output;
 }


### PR DESCRIPTION
Typos in ExportFFmpeg.cpp

Greetings,
Gootector

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I made sure the code compiles on my machine.
- [x] I made sure there are no unnecessary changes in the code.
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving.
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?".
- [x] I hereby reaffirm that I am licensing my contribution under the GNU General Public License v2.0 or later (`GPL-2.0-or-later`).
